### PR TITLE
Use `null` value for null JSON

### DIFF
--- a/json/build.gradle.kts
+++ b/json/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     jmh("org.openjdk.jmh:jmh-generator-bytecode:0.9")
     jmh("com.google.code.gson:gson:2.10.1")
 
+    implementation("org.jspecify:jspecify:1.0.0")
+
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/json/src/main/java/me/sparky983/json/InternalUnmodifiableMap.java
+++ b/json/src/main/java/me/sparky983/json/InternalUnmodifiableMap.java
@@ -4,15 +4,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A marker for an unmodifiable view of a map that is never modified after creation. Used to avoid
  * copying in the {@link Json.Object} constructor.
  */
-final class InternalUnmodifiableMap implements Map<String, Json> {
-  private final Map<String, Json> delegate;
+final class InternalUnmodifiableMap implements Map<String, @Nullable Json> {
+  private final Map<String, @Nullable Json> delegate;
 
-  InternalUnmodifiableMap(final Map<String, Json> delegate) {
+  InternalUnmodifiableMap(final Map<String, @Nullable Json> delegate) {
     this.delegate = Collections.unmodifiableMap(delegate);
   }
 
@@ -37,22 +38,22 @@ final class InternalUnmodifiableMap implements Map<String, Json> {
   }
 
   @Override
-  public Json get(final Object key) {
+  public @Nullable Json get(final Object key) {
     return delegate.get(key);
   }
 
   @Override
-  public Json put(final String key, final Json value) {
+  public @Nullable Json put(final String key, final @Nullable Json value) {
     return delegate.put(key, value);
   }
 
   @Override
-  public Json remove(final Object key) {
+  public @Nullable Json remove(final @Nullable Object key) {
     return delegate.remove(key);
   }
 
   @Override
-  public void putAll(final Map<? extends String, ? extends Json> m) {
+  public void putAll(final Map<? extends String, ? extends @Nullable Json> m) {
     delegate.putAll(m);
   }
 
@@ -67,17 +68,17 @@ final class InternalUnmodifiableMap implements Map<String, Json> {
   }
 
   @Override
-  public Collection<Json> values() {
+  public Collection<@Nullable Json> values() {
     return delegate.values();
   }
 
   @Override
-  public Set<Entry<String, Json>> entrySet() {
+  public Set<Entry<String, @Nullable Json>> entrySet() {
     return delegate.entrySet();
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     return delegate.equals(o);
   }
 

--- a/json/src/main/java/me/sparky983/json/Json.java
+++ b/json/src/main/java/me/sparky983/json/Json.java
@@ -6,21 +6,23 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 public sealed interface Json {
-  Null NULL = new Null();
-
-  static Json read(final Reader input) throws IOException, JsonParseException {
+  static @Nullable Json read(final Reader input) throws IOException, JsonParseException {
     try (final JsonReader reader = new JsonReader(input)) {
       return reader.readJson();
     }
   }
 
-  static Json read(final java.lang.String input) throws JsonParseException {
+  static @Nullable Json read(final java.lang.String input) throws JsonParseException {
     try {
       return read(new CheapStringReader(input));
     } catch (final IOException e) {
@@ -28,13 +30,13 @@ public sealed interface Json {
     }
   }
 
-  static void write(final Json json, final Writer output) throws IOException {
+  static void write(final @Nullable Json json, final Writer output) throws IOException {
     try (final JsonWriter writer = new JsonWriter(output, null)) {
       writer.writeJson(json);
     }
   }
 
-  static java.lang.String write(final Json json) {
+  static java.lang.String write(final @Nullable Json json) {
     final StringWriter stringWriter = new StringWriter();
     try (final JsonWriter jsonWriter = new JsonWriter(stringWriter, null)) {
       jsonWriter.writeJson(json);
@@ -45,7 +47,7 @@ public sealed interface Json {
   }
 
   @SuppressWarnings("unchecked")
-  static Object object(final Map<? extends java.lang.String, ? extends Json> members) {
+  static Object object(final Map<? extends java.lang.String, ? extends @Nullable Json> members) {
     if (members.isEmpty()) { // implicit null check
       return Object.EMPTY;
     }
@@ -59,15 +61,15 @@ public sealed interface Json {
   }
 
   @SuppressWarnings("unchecked")
-  static Array array(final List<? extends Json> elements) {
+  static Array array(final List<? extends @Nullable Json> elements) {
     if (elements.isEmpty()) { // implicit null check
       return Array.EMPTY;
     }
 
-    return new Array((List<Json>) elements); // safe
+    return new Array((List<@Nullable Json>) elements); // safe
   }
 
-  static Array array(final Json... elements) {
+  static Array array(final @Nullable Json... elements) {
     if (elements.length == 0) {
       return Array.EMPTY;
     }
@@ -111,7 +113,7 @@ public sealed interface Json {
     return Bool.FALSE;
   }
 
-  record Object(Map<java.lang.String, Json> members) implements Json {
+  record Object(Map<java.lang.String, @Nullable Json> members) implements Json {
     static final Object EMPTY = new Object(Map.of());
 
     public Object {
@@ -134,11 +136,10 @@ public sealed interface Json {
 
     // Not thread-safe
     public static final class Builder {
-      private LinkedHashMap<java.lang.String, Json> values = null;
+      private @Nullable LinkedHashMap<java.lang.String, @Nullable Json> values = null;
 
-      public Builder put(final java.lang.String key, final Json value) {
+      public Builder put(final java.lang.String key, final @Nullable Json value) {
         Objects.requireNonNull(key, "key");
-        Objects.requireNonNull(value, "value");
 
         if (values == null) {
           values = new LinkedHashMap<>();
@@ -152,7 +153,7 @@ public sealed interface Json {
       }
 
       public Object build() {
-        final LinkedHashMap<java.lang.String, Json> values = this.values;
+        final LinkedHashMap<java.lang.String, @Nullable Json> values = this.values;
 
         if (values == null) {
           return EMPTY;
@@ -163,19 +164,17 @@ public sealed interface Json {
     }
   }
 
-  record Array(List<Json> elements) implements Json {
+  record Array(List<@Nullable Json> elements) implements Json {
     static final Array EMPTY = new Array(List.of());
 
-    public Array(final List<Json> elements) {
+    public Array {
       if (elements instanceof InternalUnmodifiableList) {
-        this.elements = elements;
-      } else {
-        this.elements = List.copyOf(elements);
+        elements = Collections.unmodifiableList(new ArrayList<>(elements));
       }
     }
 
-    public Array(final Json... values) {
-      this(List.of(values));
+    public Array(final @Nullable Json... values) {
+      this(Arrays.asList(values));
     }
 
     @Override
@@ -233,13 +232,6 @@ public sealed interface Json {
       return this == TRUE;
     }
 
-    @Override
-    public java.lang.String toString() {
-      return write(this);
-    }
-  }
-
-  record Null() implements Json {
     @Override
     public java.lang.String toString() {
       return write(this);

--- a/json/src/main/java/me/sparky983/json/JsonException.java
+++ b/json/src/main/java/me/sparky983/json/JsonException.java
@@ -1,18 +1,20 @@
 package me.sparky983.json;
 
+import org.jspecify.annotations.Nullable;
+
 public sealed abstract class JsonException extends Exception permits JsonParseException {
   protected JsonException() {
   }
 
-  protected JsonException(final String message) {
+  protected JsonException(final @Nullable String message) {
     super(message);
   }
 
-  protected JsonException(final String message, final Throwable cause) {
+  protected JsonException(final @Nullable String message, final @Nullable Throwable cause) {
     super(message, cause);
   }
 
-  protected JsonException(final Throwable cause) {
+  protected JsonException(final @Nullable Throwable cause) {
     super(cause);
   }
 }

--- a/json/src/main/java/me/sparky983/json/JsonParseException.java
+++ b/json/src/main/java/me/sparky983/json/JsonParseException.java
@@ -1,18 +1,20 @@
 package me.sparky983.json;
 
+import org.jspecify.annotations.Nullable;
+
 public final class JsonParseException extends JsonException {
   public JsonParseException() {
   }
 
-  public JsonParseException(final String message) {
+  public JsonParseException(final @Nullable String message) {
     super(message);
   }
 
-  public JsonParseException(final String message, final Throwable cause) {
+  public JsonParseException(final @Nullable String message, final @Nullable Throwable cause) {
     super(message, cause);
   }
 
-  public JsonParseException(final Throwable cause) {
+  public JsonParseException(final @Nullable Throwable cause) {
     super(cause);
   }
 }

--- a/json/src/main/java/me/sparky983/json/JsonReader.java
+++ b/json/src/main/java/me/sparky983/json/JsonReader.java
@@ -7,6 +7,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 final class JsonReader implements AutoCloseable {
   private static final String UNKNOWN_LITERAL = "Unknown literal";
@@ -24,7 +25,7 @@ final class JsonReader implements AutoCloseable {
     this.reader = reader;
   }
 
-  Json readJson() throws IOException, JsonParseException {
+  @Nullable Json readJson() throws IOException, JsonParseException {
     final Json json = readElement();
     if (peek() != -1) {
       throw new JsonParseException("Expected end of input");
@@ -32,14 +33,14 @@ final class JsonReader implements AutoCloseable {
     return json;
   }
 
-  private Json readElement() throws IOException, JsonParseException {
+  private @Nullable Json readElement() throws IOException, JsonParseException {
     skipWhitespace();
     final Json value = readValue();
     skipWhitespace();
     return value;
   }
 
-  private Json readValue() throws IOException, JsonParseException {
+  private @Nullable Json readValue() throws IOException, JsonParseException {
     return switch (peek()) {
       case '{' -> readObject();
       case '[' -> readArray();
@@ -62,7 +63,7 @@ final class JsonReader implements AutoCloseable {
       return Json.Object.EMPTY;
     }
 
-    final LinkedHashMap<String, Json> members = new LinkedHashMap<>();
+    final LinkedHashMap<String, @Nullable Json> members = new LinkedHashMap<>();
 
     while (true) {
       if (peek() != '"') {
@@ -103,7 +104,7 @@ final class JsonReader implements AutoCloseable {
     consume();
 
     // This unmodifiable map implementations isn't copied by the Json.Object constructor
-    final Map<String, Json> unmodifiableMap = new InternalUnmodifiableMap(members);
+    final Map<String, @Nullable Json> unmodifiableMap = new InternalUnmodifiableMap(members);
 
     return new Json.Object(unmodifiableMap);
   }
@@ -117,7 +118,7 @@ final class JsonReader implements AutoCloseable {
       return Json.array();
     }
 
-    final ArrayList<Json> members = new ArrayList<>();
+    final ArrayList<@Nullable Json> members = new ArrayList<>();
 
     while (true) {
       members.add(readElement());
@@ -369,7 +370,7 @@ final class JsonReader implements AutoCloseable {
     return Json.Bool.FALSE;
   }
 
-  private Json.Null readNull() throws IOException, JsonParseException {
+  private @Nullable Json readNull() throws IOException, JsonParseException {
     consume(); // n
     final int u = peek();
     consume();
@@ -382,7 +383,7 @@ final class JsonReader implements AutoCloseable {
       throw new JsonParseException(UNKNOWN_LITERAL);
     }
 
-    return Json.NULL;
+    return null;
   }
 
   private void skipWhitespace() throws IOException {

--- a/json/src/main/java/me/sparky983/json/JsonWriter.java
+++ b/json/src/main/java/me/sparky983/json/JsonWriter.java
@@ -5,6 +5,7 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 final class JsonWriter implements AutoCloseable {
   // Implementation notes:
@@ -14,32 +15,32 @@ final class JsonWriter implements AutoCloseable {
   //  complex so copying would be too annoying to maintain.
 
   private final Writer writer;
-  private final String indentation;
+  private final @Nullable String indentation;
 
-  JsonWriter(final Writer writer, final String indentation) {
+  JsonWriter(final Writer writer, final @Nullable String indentation) {
     this.writer = writer;
     this.indentation = indentation;
   }
 
-  void writeJson(final Json json) throws IOException {
+  void writeJson(final @Nullable Json json) throws IOException {
     writeJson(json, 0);
   }
 
-  private void writeJson(final Json json, int level) throws IOException {
+  private void writeJson(final @Nullable Json json, int level) throws IOException {
     switch (json) {
       case Json.Object object -> writeObject(object, level);
       case Json.Array array -> writeArray(array, level);
       case Json.String(String string) -> writeString(string);
       case Json.Integer integer -> writeInteger(integer);
       case Json.Decimal decimal -> writeDecimal(decimal);
-      case Json.Null jsonNull -> writeNull();
       case Json.Bool.TRUE -> writeTrue();
       case Json.Bool.FALSE -> writeFalse();
+      case null -> writeNull();
     }
   }
 
   private void writeObject(final Json.Object object, final int level) throws IOException {
-    final Map<String, Json> members = object.members();
+    final Map<String, @Nullable Json> members = object.members();
 
     writer.write('{');
 
@@ -73,7 +74,7 @@ final class JsonWriter implements AutoCloseable {
   }
 
   private void writeArray(final Json.Array array, final int level) throws IOException {
-    final List<Json> elements = array.elements();
+    final List<@Nullable Json> elements = array.elements();
     final int size = elements.size();
 
     writer.write('[');

--- a/json/src/main/java/module-info.java
+++ b/json/src/main/java/module-info.java
@@ -1,4 +1,8 @@
+import org.jspecify.annotations.NullMarked;
+
 @SuppressWarnings("module") // suppress terminal digits warning
+@NullMarked
 module me.sparky983.json {
+  requires static org.jspecify;
   exports me.sparky983.json;
 }

--- a/json/src/test/java/me/sparky983/json/JsonTest.java
+++ b/json/src/test/java/me/sparky983/json/JsonTest.java
@@ -44,7 +44,7 @@ class JsonTest {
                   .put("string", Json.string("a string"))
                   .put("true", Json.Bool.TRUE)
                   .put("false", Json.Bool.FALSE)
-                  .put("null", Json.NULL)
+                  .put("null", null)
                   .build())
           .put(
               "array",
@@ -54,13 +54,13 @@ class JsonTest {
                   Json.string("a string"),
                   Json.Bool.TRUE,
                   Json.Bool.FALSE,
-                  Json.NULL))
+                  null))
           .put("integer", Json.integer(1))
           .put("decimal", Json.decimal(1.0))
           .put("string", Json.string("a string"))
           .put("true", Json.Bool.TRUE)
           .put("false", Json.Bool.FALSE)
-          .put("null", Json.NULL)
+          .put("null", null)
           .build();
 
   @Test


### PR DESCRIPTION
`record Json.Null()` is really ackward to use in pattern matching, but `null` works really well. The only drawback is that `null` produces a `NullPointerException` in switch statements by default if there is no `case null` but we can use `@Nullable` everywhere to indicate to static analysers and IDEs that they should handle the `null` case.